### PR TITLE
Add players_online api

### DIFF
--- a/apps/buddy_matching/lib/player_server/player_server.ex
+++ b/apps/buddy_matching/lib/player_server/player_server.ex
@@ -44,6 +44,12 @@ defmodule BuddyMatching.PlayerServer do
     {:reply, Map.values(list), list}
   end
 
+  # Handle calls with count - synchronous
+  # Returns {:reply, <value returned to client>, <state>}
+  def handle_call({:count}, _from, list) do
+    {:reply, Enum.count(list), list}
+  end
+
   # Handle call with add - synchronous
   # Merely add the player into the Map. Return :ok, if Player
   # was added, otherwise return :error.
@@ -106,6 +112,17 @@ defmodule BuddyMatching.PlayerServer do
   """
   def read(pid) do
     GenServer.call(pid, {:read})
+  end
+
+  @doc """
+  Returns the number players on the specified server
+  Method will run synchronously.
+  ## Examples
+  iex> BuddyMatching.PlayerServer.count(:euw)
+  10
+  """
+  def count(pid) do
+    GenServer.call(pid, {:count})
   end
 
   @doc """

--- a/apps/buddy_matching/lib/player_server/player_server.ex
+++ b/apps/buddy_matching/lib/player_server/player_server.ex
@@ -40,25 +40,25 @@ defmodule BuddyMatching.PlayerServer do
 
   # Handle calls with read - synchronous
   # Returns {:reply, <value returned to client>, <state>}
-  def handle_call({:read}, _from, list) do
-    {:reply, Map.values(list), list}
+  def handle_call({:read}, _from, state) do
+    {:reply, Map.values(state), state}
   end
 
   # Handle calls with count - synchronous
   # Returns {:reply, <value returned to client>, <state>}
-  def handle_call({:count}, _from, list) do
-    {:reply, Enum.count(list), list}
+  def handle_call({:count}, _from, state) do
+    {:reply, map_size(state), state}
   end
 
   # Handle call with add - synchronous
   # Merely add the player into the Map. Return :ok, if Player
   # was added, otherwise return :error.
   # Returns {:noreply, <value returned to client>, <state>}
-  def handle_call({:add, player}, _from, list) do
-    if Map.has_key?(list, player.name) do
-      {:reply, :error, list}
+  def handle_call({:add, player}, _from, state) do
+    if Map.has_key?(state, player.name) do
+      {:reply, :error, state}
     else
-      {:reply, :ok, Map.put_new(list, player.name, player)}
+      {:reply, :ok, Map.put_new(state, player.name, player)}
     end
   end
 

--- a/apps/buddy_matching/lib/player_server/region_mapper.ex
+++ b/apps/buddy_matching/lib/player_server/region_mapper.ex
@@ -24,6 +24,18 @@ defmodule BuddyMatching.PlayerServer.RegionMapper do
   end
 
   @doc """
+  Returns the amount of players in the given region
+  ## Examples
+      iex> BuddyMatching.RegionMapper.count_players(:euw)
+      10
+  """
+  def count_players(region) do
+    region
+    |> :global.whereis_name()
+    |> PlayerServer.count()
+  end
+
+  @doc """
   Adds the given player to a PlayerServer based
   on his region.
 

--- a/apps/buddy_matching/lib/player_server/region_mapper.ex
+++ b/apps/buddy_matching/lib/player_server/region_mapper.ex
@@ -25,6 +25,7 @@ defmodule BuddyMatching.PlayerServer.RegionMapper do
 
   @doc """
   Returns the amount of players in the given region
+
   ## Examples
       iex> BuddyMatching.RegionMapper.count_players(:euw)
       10

--- a/apps/buddy_matching/test/player_server/player_server_test.exs
+++ b/apps/buddy_matching/test/player_server/player_server_test.exs
@@ -110,4 +110,14 @@ defmodule BuddyMatching.PlayerServerTest do
     PlayerServer.update(server, player)
     assert [] = PlayerServer.read(server)
   end
+
+  test "count counts the number of players on the server", %{server: server} do
+    assert PlayerServer.count(server) == 0
+
+    # player is added
+    player = %Player{id: "1", name: "foo"}
+    PlayerServer.add(server, player)
+
+    assert PlayerServer.count(server) == 1
+  end
 end

--- a/apps/buddy_matching/test/player_server/region_mapper_test.exs
+++ b/apps/buddy_matching/test/player_server/region_mapper_test.exs
@@ -96,4 +96,14 @@ defmodule BuddyMatching.PlayerServer.RegionMapperTest do
     RegionMapper.update_player(player)
     assert [] = RegionMapper.get_players(region)
   end
+
+  test "count counts the number of players on the server", %{region1: region} do
+    assert RegionMapper.count_players(region) == 0
+
+    # player is added
+    player = %Player{id: "1", name: "foo", region: region}
+    RegionMapper.add_player(player)
+
+    assert RegionMapper.count_players(region) == 1
+  end
 end

--- a/apps/buddy_matching_web/lib/buddy_matching_web/controllers/stats_controller.ex
+++ b/apps/buddy_matching_web/lib/buddy_matching_web/controllers/stats_controller.ex
@@ -4,16 +4,14 @@ defmodule BuddyMatchingWeb.StatsController do
 
   alias BuddyMatching.PlayerServer.RegionMapper
 
-  @all_regions [:br, :eune, :euw, :jp, :kr, :lan, :las, :na, :oce, :tr, :ru, :pbe]
+  @regions [:br, :eune, :euw, :jp, :kr, :lan, :las, :na, :oce, :tr, :ru, :pbe]
 
   @doc """
   Get request to get the amount of currently connected players
   """
   def show(conn, _param) do
     stats =
-      @all_regions
-      |> Enum.map(&{&1, RegionMapper.count_players(&1)})
-      |> Enum.into(%{})
+      Enum.reduce(@regions, %{}, fn x, acc -> Map.put(acc, x, RegionMapper.count_players(x)) end)
 
     render(conn, "show.json", stats: stats)
   end

--- a/apps/buddy_matching_web/lib/buddy_matching_web/controllers/stats_controller.ex
+++ b/apps/buddy_matching_web/lib/buddy_matching_web/controllers/stats_controller.ex
@@ -1,0 +1,20 @@
+defmodule BuddyMatchingWeb.StatsController do
+  use BuddyMatchingWeb, :controller
+  action_fallback(BuddyMatchingWeb.FallbackController)
+
+  alias BuddyMatching.PlayerServer.RegionMapper
+
+  @all_regions [:br, :eune, :euw, :jp, :kr, :lan, :las, :na, :oce, :tr, :ru, :pbe]
+
+  @doc """
+  Get request to get the amount of currently connected players
+  """
+  def show(conn, _param) do
+    stats =
+      @all_regions
+      |> Enum.map(&{&1, RegionMapper.count_players(&1)})
+      |> Enum.into(%{})
+
+    render(conn, "show.json", stats: stats)
+  end
+end

--- a/apps/buddy_matching_web/lib/buddy_matching_web/router.ex
+++ b/apps/buddy_matching_web/lib/buddy_matching_web/router.ex
@@ -10,5 +10,6 @@ defmodule BuddyMatchingWeb.Router do
 
     get("/summoner/:region/:name", SummonerController, :show)
     get("/auth/request", AuthController, :show)
+    get("/stats", StatsController, :show)
   end
 end

--- a/apps/buddy_matching_web/lib/buddy_matching_web/views/stats_view.ex
+++ b/apps/buddy_matching_web/lib/buddy_matching_web/views/stats_view.ex
@@ -1,0 +1,12 @@
+defmodule BuddyMatchingWeb.StatsView do
+  use BuddyMatchingWeb, :view
+  alias BuddyMatchingWeb.StatsView
+
+  def render("show.json", %{stats: stats}) do
+    %{players_online: render_one(stats, StatsView, "players_online.json")}
+  end
+
+  def render("players_online.json", %{stats: stats}) do
+    stats
+  end
+end

--- a/apps/buddy_matching_web/test/buddy_matching_web/controllers/stats_controller_test.exs
+++ b/apps/buddy_matching_web/test/buddy_matching_web/controllers/stats_controller_test.exs
@@ -1,0 +1,53 @@
+defmodule BuddyMatching.StatsControllerTest do
+  use BuddyMatchingWeb.ConnCase
+  alias BuddyMatching.PlayerServer.RegionMapper
+  alias BuddyMatching.Players.Player
+
+  test "1 connected player to a euw server returns 1 player" do
+    player = %Player{id: "1", name: "foo", region: :euw}
+    RegionMapper.add_player(player)
+
+    conn = build_conn()
+
+    players_online =
+      conn
+      |> get(stats_path(conn, :show))
+      |> json_response(200)
+      |> Map.get("players_online")
+
+    # players should leave agin to leave no trace
+    RegionMapper.remove_player(player)
+
+    assert players_online["euw"] == 1
+
+    # all other regions should be 0
+    players_online
+    |> Map.delete("euw")
+    |> Enum.all?(fn {_server, count} -> count == 0 end)
+    |> assert
+  end
+
+  test "1 connected player to a br server returns 1 player" do
+    player = %Player{id: "1", name: "foo", region: :br}
+    RegionMapper.add_player(player)
+
+    conn = build_conn()
+
+    players_online =
+      conn
+      |> get(stats_path(conn, :show))
+      |> json_response(200)
+      |> Map.get("players_online")
+
+    # players should leave agin to leave no trace
+    RegionMapper.remove_player(player)
+
+    assert players_online["br"] == 1
+
+    # all other regions should be 0
+    players_online
+    |> Map.delete("br")
+    |> Enum.all?(fn {_server, count} -> count == 0 end)
+    |> assert
+  end
+end


### PR DESCRIPTION
I decided to try to implement this in the player servers instead of the `LeaveTracker`, since it felt more like natural to have server manage the amount of players on them and this map directly to the amount of connected players, as long as a player can only join one server at a time.
This closes #76 