### PR TITLE
Better error messages when criteria json is invalid

### DIFF
--- a/apps/buddy_matching/lib/players/criteria.ex
+++ b/apps/buddy_matching/lib/players/criteria.ex
@@ -28,10 +28,23 @@ defmodule BuddyMatching.Players.Criteria do
   Validates that the given criteria json adheres to some reasonable bounds.
   Doesn't attempt to catch errors that may be apparent from merely
   parsing the json map.
+
+  Returns {:ok} if json is validate, otherwise returns an error tuple.
   """
   def validate_criteria_json(data) do
-    map_size(data["positions"]) <= @position_limit && map_size(data["voiceChat"]) <= @voice_limit &&
-      map_size(data["ageGroups"]) <= @age_group_limit
+    cond do
+      map_size(data["positions"]) > @position_limit ->
+        {:error, "Too many positions in criteria"}
+
+      map_size(data["ageGroups"]) > @age_group_limit ->
+        {:error, "Too many age groups in criteria"}
+
+      map_size(data["voiceChat"]) > @voice_limit ->
+        {:error, "Too many values for voice chat in criteria"}
+
+      true ->
+        {:ok}
+    end
   end
 
   defp voice_parse("YES"), do: true

--- a/apps/buddy_matching/lib/players/player.ex
+++ b/apps/buddy_matching/lib/players/player.ex
@@ -11,7 +11,7 @@ defmodule BuddyMatching.Players.Player do
   @language_limit 5
   @champion_limit 3
 
-  # This module relies on the atoms defined in the Riot api module, 
+  # This module relies on the atoms defined in the Riot api module,
   # Load_atoms ensues that these are loaded before we use the module
   @on_load :load_atoms
   def load_atoms() do
@@ -102,11 +102,8 @@ defmodule BuddyMatching.Players.Player do
           String.length(data["userInfo"]["comment"]) > @comment_char_limit ->
         {:error, "Comment too long"}
 
-      !Criteria.validate_criteria_json(data["userInfo"]["criteria"]) ->
-        {:error, "Bad criteria"}
-
       true ->
-        {:ok}
+        Criteria.validate_criteria_json(data["userInfo"]["criteria"])
     end
   end
 

--- a/apps/buddy_matching/test/players/criteria_test.exs
+++ b/apps/buddy_matching/test/players/criteria_test.exs
@@ -44,4 +44,26 @@ defmodule BuddyMatching.CriteriaTest do
     expected_age_groups = ["interval1"]
     assert expected_age_groups == Criteria.age_groups_from_json(input)
   end
+
+  test "too many positions is invalid" do
+    data = Poison.Parser.parse!(@criteria)
+    bad_data = Map.update!(data, "positions", &Map.put(&1, "AFK", true))
+    assert Criteria.validate_criteria_json(bad_data) == {:error, "Too many positions in criteria"}
+  end
+
+  test "too many age groups is invalid" do
+    data = Poison.Parser.parse!(@criteria)
+    bad_data = Map.update!(data, "ageGroups", &Map.put(&1, "interval4", true))
+
+    assert Criteria.validate_criteria_json(bad_data) ==
+             {:error, "Too many age groups in criteria"}
+  end
+
+  test "too many voice chat values is invalid" do
+    data = Poison.Parser.parse!(@criteria)
+    bad_data = Map.update!(data, "voiceChat", &Map.put(&1, "MAYBE", true))
+
+    assert Criteria.validate_criteria_json(bad_data) ==
+             {:error, "Too many values for voice chat in criteria"}
+  end
 end


### PR DESCRIPTION
Gives criteria json validation the same treatment that player json validation received recently.

We could make it even more verbose my also checking with eg. `Kernel.is_map/1`, but I don't think it will be worth the effort, at least for the time being, as we shouldn't really have to spend that much time manually manipulating JSON now that tsung works (for now).