### PR TITLE
Riot api matches fix

### DIFF
--- a/apps/riot_api/lib/riot_api.ex
+++ b/apps/riot_api/lib/riot_api.ex
@@ -84,7 +84,8 @@ defmodule RiotApi do
   to get matches for any queue and returns these as a result tuple.
   """
   def fetch_recent_matches(account_id, region) do
-    fetch_recent_matches_for_queue(account_id, 20, @solo, region)
+    account_id
+    |> fetch_recent_matches_for_queue(20, @solo, region)
     |> case do
       {:ok, %{"matches" => matches} = res} when length(matches) >= 3 ->
         {:ok, res}

--- a/apps/riot_api/test/mock_json/short_matchlist.json
+++ b/apps/riot_api/test/mock_json/short_matchlist.json
@@ -1,0 +1,27 @@
+{
+  "matches": [
+    {
+      "platformId": "EUW1",
+      "gameId": 3412307012,
+      "champion": 96,
+      "queue": 420,
+      "season": 11,
+      "timestamp": 1517872970404,
+      "role": "DUO_CARRY",
+      "lane": "BOTTOM"
+    },
+    {
+      "platformId": "EUW1",
+      "gameId": 3519875372,
+      "champion": 67,
+      "queue": 420,
+      "season": 11,
+      "timestamp": 1517871086573,
+      "role": "DUO_CARRY",
+      "lane": "BOTTOM"
+    }
+  ],
+  "startIndex": 0,
+  "endIndex": 20,
+  "totalGames": 133
+}


### PR DESCRIPTION
Closes #115. Closes #65.
Fixes the uses of recently deprecated endpoint for recent matches.
Additionally we know prioritize solo queue games for deciding recently played champions for a summoner. If less than 3 solo queue games can be found, then we find 20 games from any queue and bases our champions off that.