### PR TITLE
Fortnite stats fix

### DIFF
--- a/apps/fortnite_api/lib/fortnite_api.ex
+++ b/apps/fortnite_api/lib/fortnite_api.ex
@@ -70,14 +70,16 @@ defmodule FortniteApi do
 
     iex> FortniteApi.fetch_stats("Trollerenn", "PC")
     {:ok,
-      %{"duo" => %{
-       "gamesPlayed" => 5,
-       "gamesWon" => 0,
-       "killDeathRatio" => 1.2,
-       "top1finishes" => 0,
-       "top3finishes" => 0,
-       "top5finishes" => 0
+      %{"solo" => %{
+       "gamesPlayed" => 20,
+       "gamesWon" => 2,
+       "killDeathRatio" => 4.9,
+       "top1finishes" => 2,
+       "top10finishes" => 5,
+       "top25finishes" => 10
      },
+     "duo" => %{..},
+     "squad" => %{..},
      "platform" => "pc",
      "total" => %{"gamesPlayed" => 27, "gamesWon" => 1},
      "username" => "trollerenn"

--- a/apps/fortnite_api/lib/fortnite_api.ex
+++ b/apps/fortnite_api/lib/fortnite_api.ex
@@ -48,7 +48,7 @@ defmodule FortniteApi do
     iex> FortniteApi.validate_platform("PC")
     {:ok, "pc"}
     iex> FortniteApi.validate_platform("GAMEBOY")
-    {:error, "Bad paltform. Should be xb1/ps4/pc."}
+    {:error, "Bad platform. Should be xb1/ps4/pc."}
 
   """
   def validate_platform(platform) do
@@ -92,7 +92,7 @@ defmodule FortniteApi do
       stats <- fetch_br_stats(account_id, access_token)
     after
       stats
-      |> Stats.get_duo_stats(platform)
+      |> Stats.get_stats(platform)
       |> Map.put("username", display_name)
       |> Map.put("platform", platform)
     end

--- a/apps/fortnite_api/lib/fortnite_api/stats.ex
+++ b/apps/fortnite_api/lib/fortnite_api/stats.ex
@@ -34,6 +34,7 @@ defmodule FortniteApi.Stats do
   defp get_solo_stats(stats, platform) do
     top10 = Map.get(stats, "br_placetop10_#{platform}_m0_#{@solo}", 0)
     top25 = Map.get(stats, "br_placetop25_#{platform}_m0_#{@solo}", 0)
+
     stats
     |> get_shared_queue_stats(@solo, platform)
     |> Map.put("top10finishes", top10)
@@ -43,6 +44,7 @@ defmodule FortniteApi.Stats do
   defp get_duo_stats(stats, platform) do
     top5 = Map.get(stats, "br_placetop5_#{platform}_m0_#{@duo}", 0)
     top12 = Map.get(stats, "br_placetop12_#{platform}_m0_#{@duo}", 0)
+
     stats
     |> get_shared_queue_stats(@duo, platform)
     |> Map.put("top5finishes", top5)
@@ -52,6 +54,7 @@ defmodule FortniteApi.Stats do
   defp get_squad_stats(stats, platform) do
     top3 = Map.get(stats, "br_placetop3_#{platform}_m0_#{@squad}", 0)
     top6 = Map.get(stats, "br_placetop6_#{platform}_m0_#{@squad}", 0)
+
     stats
     |> get_shared_queue_stats(@squad, platform)
     |> Map.put("top3finishes", top3)
@@ -99,6 +102,7 @@ defmodule FortniteApi.Stats do
     squad_stats = get_squad_stats(stats, platform)
     total_games = solo_stats["gamesPlayed"] + duo_stats["gamesPlayed"] + squad_stats["gamesWon"]
     total_wins = solo_stats["gamesWon"] + duo_stats["gamesWon"] + squad_stats["gamesWon"]
+
     %{
       "total" => %{
         "totalGamesPlayed" => total_games,

--- a/apps/fortnite_api/lib/fortnite_api/stats.ex
+++ b/apps/fortnite_api/lib/fortnite_api/stats.ex
@@ -8,20 +8,6 @@ defmodule FortniteApi.Stats do
   @duo "p10"
   @squad "p9"
 
-  @doc """
-  Formats the list of maps returned by Fornite's API
-  as a Map of %{"stat_type" => "value}.
-
-  ## Examples:
-
-    iex> format_stats([%{"name" => "br_score_pc_m0_p10", "value" => 703}])
-    %{"br_score_pc_m0_p10" => 703}
-
-  """
-  def format_stats(stats) do
-    Enum.reduce(stats, %{}, fn x, acc -> Map.put(acc, x["name"], x["value"]) end)
-  end
-
   defp get_shared_queue_stats(stats, queue, platform) do
     games = Map.get(stats, "br_matchesplayed_#{platform}_m0_#{queue}", 0)
     wins = Map.get(stats, "br_placetop1_#{platform}_m0_#{queue}", 0)
@@ -59,6 +45,20 @@ defmodule FortniteApi.Stats do
     |> get_shared_queue_stats(@squad, platform)
     |> Map.put("top3finishes", top3)
     |> Map.put("top6finishes", top6)
+  end
+
+  @doc """
+  Formats the list of maps returned by Fornite's API
+  as a Map of %{"stat_type" => "value}.
+
+  ## Examples:
+
+    iex> format_stats([%{"name" => "br_score_pc_m0_p10", "value" => 703}])
+    %{"br_score_pc_m0_p10" => 703}
+
+  """
+  def format_stats(stats) do
+    Enum.reduce(stats, %{}, fn x, acc -> Map.put(acc, x["name"], x["value"]) end)
   end
 
   @doc """

--- a/apps/fortnite_api/test/fortnite_api/stats_test.exs
+++ b/apps/fortnite_api/test/fortnite_api/stats_test.exs
@@ -2,165 +2,78 @@ defmodule FortniteApi.StatsTest do
   alias FortniteApi.Stats
   use ExUnit.Case, async: true
 
-  # @solo "p2"
-  @duo "p10"
-  # @squad "p9"
+  setup_all do
+    stats =
+      "test/mock_json/stats.json"
+      |> File.read!()
+      |> Poison.decode!()
 
-  @fortnite_stats [
-    %{
-      "name" => "br_score_pc_m0_p10",
-      "ownerType" => 1,
-      "value" => 703,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_score_pc_m0_p9",
-      "ownerType" => 1,
-      "value" => 2669,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_matchesplayed_pc_m0_p10",
-      "ownerType" => 1,
-      "value" => 5,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_score_pc_m0_p2",
-      "ownerType" => 1,
-      "value" => 678,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_kills_pc_m0_p2",
-      "ownerType" => 1,
-      "value" => 2,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_lastmodified_pc_m0_p9",
-      "ownerType" => 1,
-      "value" => 1_521_842_991,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_lastmodified_pc_m0_p2",
-      "ownerType" => 1,
-      "value" => 1_521_834_802,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_matchesplayed_pc_m0_p2",
-      "ownerType" => 1,
-      "value" => 2,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_kills_pc_m0_p9",
-      "ownerType" => 1,
-      "value" => 14,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_placetop1_pc_m0_p2",
-      "ownerType" => 1,
-      "value" => 1,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_matchesplayed_pc_m0_p9",
-      "ownerType" => 1,
-      "value" => 20,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_placetop12_pc_m0_p10",
-      "ownerType" => 1,
-      "value" => 2,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_lastmodified_pc_m0_p10",
-      "ownerType" => 1,
-      "value" => 1_521_986_670,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_placetop10_pc_m0_p2",
-      "ownerType" => 1,
-      "value" => 1,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_placetop25_pc_m0_p2",
-      "ownerType" => 1,
-      "value" => 1,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_kills_pc_m0_p10",
-      "ownerType" => 1,
-      "value" => 6,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_placetop6_pc_m0_p9",
-      "ownerType" => 1,
-      "value" => 3,
-      "window" => "alltime"
-    }
-  ]
+    [stats: stats]
+  end
 
-  test "format_stats/1 formats correctly" do
+  test "format_stats/1 formats correctly", context do
+    stats = context[:stats]
+
     expected_output = %{
-      "br_kills_pc_m0_p10" => 6,
-      "br_kills_pc_m0_p2" => 2,
-      "br_kills_pc_m0_p9" => 14,
-      "br_lastmodified_pc_m0_p10" => 1_521_986_670,
-      "br_lastmodified_pc_m0_p2" => 1_521_834_802,
-      "br_lastmodified_pc_m0_p9" => 1_521_842_991,
-      "br_matchesplayed_pc_m0_p10" => 5,
-      "br_matchesplayed_pc_m0_p2" => 2,
-      "br_matchesplayed_pc_m0_p9" => 20,
-      "br_placetop10_pc_m0_p2" => 1,
-      "br_placetop12_pc_m0_p10" => 2,
-      "br_placetop1_pc_m0_p2" => 1,
-      "br_placetop25_pc_m0_p2" => 1,
-      "br_placetop6_pc_m0_p9" => 3,
-      "br_score_pc_m0_p10" => 703,
-      "br_score_pc_m0_p2" => 678,
-      "br_score_pc_m0_p9" => 2669
+      "br_kills_pc_m0_p10" => 20129,
+      "br_kills_pc_m0_p2" => 26746,
+      "br_kills_pc_m0_p9" => 10133,
+      "br_lastmodified_pc_m0_p10" => 1_526_704_368,
+      "br_lastmodified_pc_m0_p2" => 1_526_660_886,
+      "br_lastmodified_pc_m0_p9" => 1_526_719_560,
+      "br_matchesplayed_pc_m0_p10" => 2769,
+      "br_matchesplayed_pc_m0_p2" => 3458,
+      "br_matchesplayed_pc_m0_p9" => 1613,
+      "br_placetop10_pc_m0_p2" => 1562,
+      "br_placetop12_pc_m0_p10" => 1626,
+      "br_placetop1_pc_m0_p2" => 1190,
+      "br_placetop25_pc_m0_p2" => 1876,
+      "br_placetop6_pc_m0_p9" => 553,
+      "br_score_pc_m0_p10" => 1_190_306,
+      "br_score_pc_m0_p2" => 1_142_038,
+      "br_score_pc_m0_p9" => 447_601,
+      "br_minutesplayed_pc_m0_p10" => 17407,
+      "br_minutesplayed_pc_m0_p2" => 24386,
+      "br_minutesplayed_pc_m0_p9" => 8298,
+      "br_placetop1_pc_m0_p10" => 1181,
+      "br_placetop1_pc_m0_p9" => 361,
+      "br_placetop3_pc_m0_p9" => 457,
+      "br_placetop5_pc_m0_p10" => 1386
     }
 
-    actual_output = Stats.format_stats(@fortnite_stats)
+    actual_output = Stats.format_stats(stats)
     assert expected_output == actual_output
   end
 
-  test "get_stats_for_queue/3 fetches correct results" do
-    stats = Stats.format_stats(@fortnite_stats)
-    {games, kills, wins, top3, top5} = Stats.get_stats_for_queue(stats, "pc", @duo)
+  test "get_stats/2 correctly extracts and formats pc stats from all stats", context do
+    stats = context[:stats]
 
-    assert 5 == games
-    assert 6 == kills
-    assert 0 == wins
-    assert 0 == top3
-    assert 0 == top5
-  end
-
-  test "get_duo_stats/2 correctly extracts and  formats duo pc stats from all stats" do
     expected_output = %{
       "duo" => %{
-        "gamesPlayed" => 5,
-        "gamesWon" => 0,
-        "killDeathRatio" => 1.2,
-        "top1finishes" => 0,
-        "top3finishes" => 0,
-        "top5finishes" => 0
+        "gamesPlayed" => 2769,
+        "gamesWon" => 1181,
+        "killDeathRatio" => 12.675692695214106,
+        "top12finishes" => 1626,
+        "top5finishes" => 1386
       },
-      "total" => %{"totalGamesPlayed" => 27, "totalGamesWon" => 1}
+      "solo" => %{
+        "gamesPlayed" => 3458,
+        "gamesWon" => 1190,
+        "killDeathRatio" => 11.792768959435627,
+        "top10finishes" => 1562,
+        "top25finishes" => 1876
+      },
+      "squad" => %{
+        "gamesPlayed" => 1613,
+        "gamesWon" => 361,
+        "killDeathRatio" => 8.093450479233226,
+        "top3finishes" => 457,
+        "top6finishes" => 553
+      },
+      "total" => %{"totalGamesPlayed" => 6588, "totalGamesWon" => 2732}
     }
 
-    actual_output = Stats.get_duo_stats(@fortnite_stats, "pc")
+    actual_output = Stats.get_stats(stats, "pc")
     assert expected_output == actual_output
   end
 end

--- a/apps/fortnite_api/test/fortnite_api_mock_test.exs
+++ b/apps/fortnite_api/test/fortnite_api_mock_test.exs
@@ -5,195 +5,120 @@ defmodule FortniteApi.MockTest do
 
   import Mock
 
-  @token "MOCK_TOKEN"
-  @fortnite_stats [
-    %{
-      "name" => "br_score_pc_m0_p10",
-      "ownerType" => 1,
-      "value" => 703,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_score_pc_m0_p9",
-      "ownerType" => 1,
-      "value" => 2669,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_matchesplayed_pc_m0_p10",
-      "ownerType" => 1,
-      "value" => 5,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_score_pc_m0_p2",
-      "ownerType" => 1,
-      "value" => 678,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_kills_pc_m0_p2",
-      "ownerType" => 1,
-      "value" => 2,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_lastmodified_pc_m0_p9",
-      "ownerType" => 1,
-      "value" => 1_521_842_991,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_lastmodified_pc_m0_p2",
-      "ownerType" => 1,
-      "value" => 1_521_834_802,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_matchesplayed_pc_m0_p2",
-      "ownerType" => 1,
-      "value" => 2,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_kills_pc_m0_p9",
-      "ownerType" => 1,
-      "value" => 14,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_placetop1_pc_m0_p2",
-      "ownerType" => 1,
-      "value" => 1,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_matchesplayed_pc_m0_p9",
-      "ownerType" => 1,
-      "value" => 20,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_placetop12_pc_m0_p10",
-      "ownerType" => 1,
-      "value" => 2,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_lastmodified_pc_m0_p10",
-      "ownerType" => 1,
-      "value" => 1_521_986_670,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_placetop10_pc_m0_p2",
-      "ownerType" => 1,
-      "value" => 1,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_placetop25_pc_m0_p2",
-      "ownerType" => 1,
-      "value" => 1,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_kills_pc_m0_p10",
-      "ownerType" => 1,
-      "value" => 6,
-      "window" => "alltime"
-    },
-    %{
-      "name" => "br_placetop6_pc_m0_p9",
-      "ownerType" => 1,
-      "value" => 3,
-      "window" => "alltime"
-    }
-  ]
+  setup_all do
+    token = "MOCK_TOKEN"
+    username = "Ninja"
+    platform = "PC"
+    account_id = "123456789"
+    account_id_json = File.read!("test/mock_json/account_id.json")
+    stats_json = File.read!("test/mock_json/stats.json")
+
+    account_id_url =
+      "https://persona-public-service-prod06.ol.epicgames.com/persona/api/public/account/lookup?q=#{
+        username
+      }"
+
+    stats_url =
+      "https://fortnite-public-service-prod11.ol.epicgames.com/fortnite/api/stats/accountId/#{
+        account_id
+      }/bulk/window/alltime"
+
+    [
+      username: username,
+      platform: platform,
+      token: token,
+      account_id: account_id,
+      stats_json: stats_json,
+      account_id_json: account_id_json,
+      stats_url: stats_url,
+      account_id_url: account_id_url
+    ]
+  end
 
   defp success_response(value), do: {:ok, %{status_code: 200, body: value}}
   defp error_response(value), do: {:error, %{status_code: 404, body: value}}
 
-  defp account_id_url(username) do
-    "https://persona-public-service-prod06.ol.epicgames.com/persona/api/public/account/lookup?q=#{
-      username
-    }"
-  end
-
-  defp br_stats_url(account_id) do
-    "https://fortnite-public-service-prod11.ol.epicgames.com/fortnite/api/stats/accountId/#{
-      account_id
-    }/bulk/window/alltime"
-  end
-
-  test "fetch_stats with correct access returns expected stats" do
-    headers = AccessServer.get_headers_bearer(@token)
-    username = "trollerenn"
-    platform = "pc"
-    account_id = "123456789"
-    account_id_url = account_id_url(username)
-    stats_url = br_stats_url(account_id)
-
-    id_response = Poison.encode!(%{"id" => account_id, "displayName" => username})
-    stats_response = Poison.encode!(@fortnite_stats)
+  test "fetch_stats with correct access returns expected stats", context do
+    token = context[:token]
+    headers = AccessServer.get_headers_bearer(token)
+    username = context[:username]
+    platform = context[:platform]
+    account_id_url = context[:account_id_url]
+    stats_url = context[:stats_url]
+    stats_response = context[:stats_json]
+    account_id_response = context[:account_id_json]
 
     expected_output =
       {:ok,
        %{
-         "username" => username,
-         "platform" => platform,
+         "username" => "Ninja",
          "duo" => %{
-           "gamesPlayed" => 5,
-           "gamesWon" => 0,
-           "killDeathRatio" => 1.2,
-           "top1finishes" => 0,
-           "top3finishes" => 0,
-           "top5finishes" => 0
+           "gamesPlayed" => 2769,
+           "gamesWon" => 1181,
+           "killDeathRatio" => 12.675692695214106,
+           "top5finishes" => 1386,
+           "top12finishes" => 1626
          },
-         "total" => %{"totalGamesPlayed" => 27, "totalGamesWon" => 1}
+         "platform" => "pc",
+         "total" => %{"totalGamesPlayed" => 6588, "totalGamesWon" => 2732},
+         "solo" => %{
+           "gamesPlayed" => 3458,
+           "gamesWon" => 1190,
+           "killDeathRatio" => 11.792768959435627,
+           "top10finishes" => 1562,
+           "top25finishes" => 1876
+         },
+         "squad" => %{
+           "gamesPlayed" => 1613,
+           "gamesWon" => 361,
+           "killDeathRatio" => 8.093450479233226,
+           "top3finishes" => 457,
+           "top6finishes" => 553
+         }
        }}
 
     with_mocks([
       {HTTPoison, [],
        [
          get: fn
-           ^account_id_url, ^headers -> success_response(id_response)
+           ^account_id_url, ^headers -> success_response(account_id_response)
            ^stats_url, ^headers -> success_response(stats_response)
          end
        ]},
-      {AccessServer, [:passthrough], [get_token: fn -> {:ok, @token} end]}
+      {AccessServer, [:passthrough], [get_token: fn -> {:ok, token} end]}
     ]) do
       assert expected_output == FortniteApi.fetch_stats(username, platform)
     end
   end
 
-  test "fetch_stats with unsuccesful token requests returns error tuple" do
+  test "fetch_stats with unsuccesful token requests returns error tuple", context do
+    username = context[:username]
+    platform = context[:platform]
     error_message = "Failed to get token"
 
     with_mock(AccessServer, get_token: fn -> {:error, error_message} end) do
-      assert {:error, ^error_message} = FortniteApi.fetch_stats("trollerenn", "pc")
+      assert {:error, ^error_message} = FortniteApi.fetch_stats(username, platform)
     end
   end
 
-  test "fetch_stats with unsuccesful web request returns error tuple" do
-    headers = AccessServer.get_headers_bearer(@token)
-    username = "trollerenn"
-    platform = "pc"
-    account_id = "123456789"
-    account_id_url = account_id_url(username)
-    stats_url = br_stats_url(account_id)
-
-    id_response = Poison.encode!(%{"id" => account_id, "displayName" => username})
+  test "fetch_stats with unsuccesful web request returns error tuple", context do
+    token = context[:token]
+    headers = AccessServer.get_headers_bearer(token)
+    username = context[:username]
+    platform = context[:platform]
+    account_id_url = context[:account_id_url]
+    stats_url = context[:stats_url]
+    account_id_response = context[:account_id_json]
 
     with_mocks([
       {HTTPoison, [],
        [
          get: fn
-           ^account_id_url, ^headers -> success_response(id_response)
+           ^account_id_url, ^headers -> success_response(account_id_response)
            ^stats_url, ^headers -> error_response("Couldn't get stats")
          end
        ]},
-      {AccessServer, [:passthrough], [get_token: fn -> {:ok, @token} end]}
+      {AccessServer, [:passthrough], [get_token: fn -> {:ok, token} end]}
     ]) do
       assert {:error, "Couldn't get stats"} = FortniteApi.fetch_stats(username, platform)
     end

--- a/apps/fortnite_api/test/mock_json/account_id.json
+++ b/apps/fortnite_api/test/mock_json/account_id.json
@@ -1,0 +1,4 @@
+{
+  "id": "123456789",
+  "displayName": "Ninja"
+}

--- a/apps/fortnite_api/test/mock_json/stats.json
+++ b/apps/fortnite_api/test/mock_json/stats.json
@@ -1,0 +1,146 @@
+[
+  {
+    "name": "br_score_pc_m0_p10",
+    "value": 1190306,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_score_pc_m0_p9",
+    "value": 447601,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_matchesplayed_pc_m0_p10",
+    "value": 2769,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_placetop3_pc_m0_p9",
+    "value": 457,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_score_pc_m0_p2",
+    "value": 1142038,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_kills_pc_m0_p2",
+    "value": 26746,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_lastmodified_pc_m0_p9",
+    "value": 1526719560,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_lastmodified_pc_m0_p2",
+    "value": 1526660886,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_matchesplayed_pc_m0_p2",
+    "value": 3458,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_kills_pc_m0_p9",
+    "value": 10133,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_minutesplayed_pc_m0_p2",
+    "value": 24386,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_placetop1_pc_m0_p2",
+    "value": 1190,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_matchesplayed_pc_m0_p9",
+    "value": 1613,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_placetop12_pc_m0_p10",
+    "value": 1626,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_lastmodified_pc_m0_p10",
+    "value": 1526704368,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_placetop1_pc_m0_p10",
+    "value": 1181,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_minutesplayed_pc_m0_p10",
+    "value": 17407,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_placetop10_pc_m0_p2",
+    "value": 1562,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_minutesplayed_pc_m0_p9",
+    "value": 8298,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_placetop25_pc_m0_p2",
+    "value": 1876,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_placetop5_pc_m0_p10",
+    "value": 1386,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_kills_pc_m0_p10",
+    "value": 20129,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_placetop6_pc_m0_p9",
+    "value": 553,
+    "window": "alltime",
+    "ownerType": 1
+  },
+  {
+    "name": "br_placetop1_pc_m0_p9",
+    "value": 361,
+    "window": "alltime",
+    "ownerType": 1
+  }
+]


### PR DESCRIPTION
Closes #119 
We now aggregate and send stats for all queues, because... we might as well!
`fortnite_api` now also uses the same mock test style that `riot_api` uses, in the form of loading .json-files taken from a live setting.