### PR TITLE
Elixir 1.7

### DIFF
--- a/apps/buddy_matching/lib/players/matching/lol_matching.ex
+++ b/apps/buddy_matching/lib/players/matching/lol_matching.ex
@@ -81,29 +81,18 @@ defmodule BuddyMatching.Players.Matching.LolMatching do
 
     cond do
       # master and challenger have equal restrictions
-      ht == "MASTER" || ht == "CHALLENGER" ->
-        lr in 1..3
-
+      ht == "MASTER" || ht == "CHALLENGER" -> lr in 1..3
       # now we may can assume ht is diamond
       # we also know if hr is diamond, lt has to be platinum
-      hr == 1 ->
-        ht == lt && lr in 1..4
-
+      hr == 1 -> ht == lt && lr in 1..4
       # d2 can't queue with plat (shouldn't happen tho)
-      hr == 2 ->
-        false
-
+      hr == 2 -> false
       # d3 can queue with plat 1
-      hr == 3 ->
-        lr == 1
-
+      hr == 3 -> lr == 1
       # d4 can queue with plat 1/2
-      hr == 4 ->
-        lr in 1..2
-
+      hr == 4 -> lr in 1..2
       # d5 can queue with plat 1..3
-      hr == 5 ->
-        lr in 1..3
+      hr == 5 -> lr in 1..3
     end
   end
 
@@ -171,30 +160,15 @@ defmodule BuddyMatching.Players.Matching.LolMatching do
 
   defp tier_to_int(tier) do
     case tier do
-      "BRONZE" ->
-        1
-
+      "BRONZE" -> 1
       # Riot treats unrankeds like silvers
-      "UNRANKED" ->
-        2
-
-      "SILVER" ->
-        2
-
-      "GOLD" ->
-        3
-
-      "PLATINUM" ->
-        4
-
-      "DIAMOND" ->
-        5
-
-      "MASTER" ->
-        6
-
-      "CHALLENGER" ->
-        6
+      "UNRANKED" -> 2
+      "SILVER" -> 2
+      "GOLD" -> 3
+      "PLATINUM" -> 4
+      "DIAMOND" -> 5
+      "MASTER" -> 6
+      "CHALLENGER" -> 6
     end
   end
 

--- a/apps/buddy_matching/mix.exs
+++ b/apps/buddy_matching/mix.exs
@@ -5,7 +5,7 @@ defmodule BuddyMatching.Mixfile do
     [
       app: :buddy_matching,
       version: auto_version(),
-      elixir: "~> 1.6",
+      elixir: "~> 1.7",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/buddy_matching_web/mix.exs
+++ b/apps/buddy_matching_web/mix.exs
@@ -5,7 +5,7 @@ defmodule BuddyMatchingWeb.Mixfile do
     [
       app: :buddy_matching_web,
       version: auto_version(),
-      elixir: "~> 1.6",
+      elixir: "~> 1.7",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/fortnite_api/mix.exs
+++ b/apps/fortnite_api/mix.exs
@@ -5,7 +5,7 @@ defmodule FortniteApi.Mixfile do
     [
       app: :fortnite_api,
       version: auto_version(),
-      elixir: "~> 1.6",
+      elixir: "~> 1.7",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/riot_api/mix.exs
+++ b/apps/riot_api/mix.exs
@@ -5,7 +5,7 @@ defmodule RiotApi.Mixfile do
     [
       app: :riot_api,
       version: auto_version(),
-      elixir: "~> 1.6",
+      elixir: "~> 1.7",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,5 +1,5 @@
 # Erlang version
-erlang_version=20.1
+erlang_version=21.0
 
 # Elixir version
-elixir_version=1.5.1
+elixir_version=1.7.1


### PR DESCRIPTION
Runs the new formatter which finally fixes the yucky formatting that it did on `lol_matching.exs` thanks to https://github.com/elixir-lang/elixir/issues/7742 and updates our Heroku buildpack.

Closes #125 