### PR TITLE
Fortnite Matching [WIP]

### DIFF
--- a/apps/buddy_matching/lib/players/criteria/fortnite_criteria.ex
+++ b/apps/buddy_matching/lib/players/criteria/fortnite_criteria.ex
@@ -8,7 +8,7 @@ defmodule BuddyMatching.Players.Criteria.FortniteCriteria do
   alias BuddyMatching.Players.FromJsonBehaviour
   @behaviour FromJsonBehaviour
 
-  defstruct positions: []
+  defstruct min_games_played: 0
 
   @doc """
   Parses the checkbox format the frontend uses for criteria

--- a/apps/buddy_matching/lib/players/info/fortnite_info.ex
+++ b/apps/buddy_matching/lib/players/info/fortnite_info.ex
@@ -8,7 +8,9 @@ defmodule BuddyMatching.Players.Info.FortniteInfo do
   alias BuddyMatching.Players.FromJsonBehaviour
   @behaviour FromJsonBehaviour
 
-  defstruct game_criteria: nil, platform: nil
+  defstruct game_criteria: nil,
+            platform: nil,
+            games_played: 0
 
   @platforms %{"pc" => :pc, "ps4" => :ps4, "xbox" => :xb1}
 

--- a/apps/buddy_matching/lib/players/matching/fortnite_matching.ex
+++ b/apps/buddy_matching/lib/players/matching/fortnite_matching.ex
@@ -2,10 +2,31 @@ defmodule BuddyMatching.Players.Matching.FortniteMatching do
   @moduledoc false
 
   alias BuddyMatching.Players.Info.FortniteInfo
+  alias BuddyMatching.Players.Criteria.FortniteCriteria
   alias BuddyMatching.Players.MatchingBehaviour
   @behaviour MatchingBehaviour
 
+  @doc """
+  Checks whether 2 FortniteInfos are compatible. This is done by
+  checking platform compatability, as well as mutual criteria compatability.
+  """
   def match?(%FortniteInfo{} = player, %FortniteInfo{} = candidate) do
-    player.platform == candidate.platform
+    player.platform == candidate.platform && criteria_compatible?(player.game_criteria, candidate) &&
+      criteria_compatible?(candidate.game_criteria, player)
+  end
+
+  @doc """
+  Checks whether a FortniteCriteria is valid for queuing with the given FortniteInfo.
+  In practise this determines whether the minimum games played in the criteria is met
+  by the given FortniteInfo.
+
+  ## Examples
+    iex> info = %FortniteInfo{games_played: 12}
+    iex> criteria = %FortniteCriteria{min_games_played: 10}
+    iex> criteria_compatible?(criteria, info)
+    true
+  """
+  def criteria_compatible?(%FortniteCriteria{} = criteria, %FortniteInfo{} = info) do
+    criteria.min_games_played <= info.games_played
   end
 end

--- a/apps/buddy_matching/test/players/matching/fortnite_matching_test.exs
+++ b/apps/buddy_matching/test/players/matching/fortnite_matching_test.exs
@@ -1,18 +1,27 @@
 defmodule BuddyMatching.Matching.FortniteMatchingTest do
   use ExUnit.Case, async: true
   alias BuddyMatching.Players.Info.FortniteInfo
-  # alias BuddyMatching.Players.Criteria.FortniteCriteria
+  alias BuddyMatching.Players.Criteria.FortniteCriteria
   alias BuddyMatching.Players.Matching.FortniteMatching, as: Matching
 
-  test "fortnite players match when on same platform" do
-    p1 = %FortniteInfo{platform: :xb1}
-    p2 = %FortniteInfo{platform: :xb1}
+  @criteria10 %FortniteCriteria{min_games_played: 10}
+  @criteria5 %FortniteCriteria{min_games_played: 5}
+
+  test "fortnite players match matches based on platform" do
+    p1 = %FortniteInfo{platform: :xb1, games_played: 11, game_criteria: @criteria10}
+    p2 = %FortniteInfo{platform: :xb1, games_played: 12, game_criteria: @criteria10}
+    p3 = %FortniteInfo{platform: :ps4, games_played: 13, game_criteria: @criteria10}
     assert Matching.match?(p1, p2)
+    refute Matching.match?(p2, p3)
+    refute Matching.match?(p1, p3)
   end
 
-  test "fortnite players do not match if on different platforms" do
-    p1 = %FortniteInfo{platform: :ps4}
-    p2 = %FortniteInfo{platform: :xb1}
+  test "fortnite players match based on games_played" do
+    p1 = %FortniteInfo{platform: :ps4, games_played: 13, game_criteria: @criteria10}
+    p2 = %FortniteInfo{platform: :ps4, games_played: 9, game_criteria: @criteria10}
+    p3 = %FortniteInfo{platform: :ps4, games_played: 11, game_criteria: @criteria5}
     refute Matching.match?(p1, p2)
+    assert Matching.match?(p2, p3)
+    assert Matching.match?(p1, p3)
   end
 end


### PR DESCRIPTION
Implements the matching logic for Fortnite players, based solely on games played for starters.
WIP, in the sense that JSON parsing is currently missing for the `FortniteInfo` and `FortniteCriteria`.

Closes #95 